### PR TITLE
Persistent upload log, date-bounded cashback rates, and shared date utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,3 @@ Thumbs.db
 *.bak
 
 uploaded_log.json
-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Thumbs.db
 # Temporary Files
 *.tmp
 *.bak
+
+uploaded_log.json
+config.json

--- a/add_transaction.py
+++ b/add_transaction.py
@@ -8,6 +8,7 @@ from typing import Dict, Any, Optional
 from datetime import datetime
 from src.utils.logger import get_logger
 from src.utils.config_loader import get_card_cashback
+from src.utils.date_utils import parse_expense_date
 
 
 logger = get_logger()
@@ -33,7 +34,7 @@ def prompt_transaction_details() -> Dict[str, Any]:
             transaction['date'] = datetime.now().strftime('%Y-%m-%d')
             break
         try:
-            transaction['date'] = parse_transaction_date(date_input)
+            transaction['date'] = parse_expense_date(date_input)
             break
         except ValueError as e:
             print(f"Invalid date format: {e}. Please try again.")
@@ -76,53 +77,6 @@ def prompt_transaction_details() -> Dict[str, Any]:
     return transaction
 
 
-def parse_transaction_date(date_str: str) -> str:
-    """
-    Parse date string into YYYY-MM-DD format.
-    
-    Args:
-        date_str: Date string in various formats
-    
-    Returns:
-        Date in YYYY-MM-DD format
-    
-    Raises:
-        ValueError: If date cannot be parsed
-    """
-    date_formats = [
-        '%Y-%m-%d',      # 2026-03-15
-        '%m/%d/%y',      # 03/15/26
-        '%m/%d/%Y',      # 03/15/2026
-        '%Y/%m/%d',      # 2026/03/15
-    ]
-    
-    for fmt in date_formats:
-        try:
-            date_obj = datetime.strptime(date_str, fmt)
-            return date_obj.strftime('%Y-%m-%d')
-        except ValueError:
-            continue
-    
-    # Manual parsing as fallback
-    try:
-        parts = date_str.replace('/', '-').split('-')
-        if len(parts) == 3:
-            # Try YYYY-MM-DD format
-            if len(parts[0]) == 4:
-                year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
-            else:
-                # Try MM-DD-YY format
-                month, day, year = int(parts[0]), int(parts[1]), int(parts[2])
-                if year < 100:
-                    year = 2000 + year if year < 50 else 1900 + year
-            
-            return f"{year:04d}-{month:02d}-{day:02d}"
-    except (ValueError, IndexError):
-        pass
-    
-    raise ValueError(f"Could not parse date '{date_str}'")
-
-
 def calculate_transaction_amount(
     transaction: Dict[str, Any],
     config: Dict[str, Any]
@@ -148,7 +102,8 @@ def calculate_transaction_amount(
     cashback_rate = get_card_cashback(
         config,
         transaction['account'],
-        transaction['category']
+        transaction['category'],
+        transaction.get('date')
     )
     
     cashback_amount = original_amount * cashback_rate

--- a/config.json
+++ b/config.json
@@ -1,6 +1,17 @@
 {
+  "card_aliases": {
+    "Savor - Ending in 9209": "savor",
+    "Customized Cash Rewards Visa Signature ( ) - Ending in 4388": "bofa_customized_cash",
+    "Travel Rewards Visa Signature ( ) - Ending in 8067": "bofa_travel",
+    "Citi Custom Cash Card - Ending in 9673": "citi_custom_cash",
+    "Discover It Card - Ending in 7693": "discover_it",
+    "Chase Freedom- Ending in 8642": "chase_freedom",
+    "Amazon Credit Card - Ending in 7980": "amazon_card",
+    "Blue Cash Everyday ( ) - Ending in 1006": "bofa_blue_cash",
+    "Citi Double Cash Card - Ending in 1713": "citi_double_cash"
+  },
   "cards": {
-    "Savor - Ending in 9209": {
+    "savor": {
       "categories": {
         "Restaurants": 0.03,
         "Groceries": 0.03,
@@ -8,45 +19,49 @@
       },
       "default_cashback": 0.01
     },
-    "Customized Cash Rewards Visa Signature ( ) - Ending in 4388": {
+    "bofa_customized_cash": {
       "categories": {
         "Groceries": 0.02,
         "Online": 0.03
       },
       "default_cashback": 0.01
     },
-    "Travel Rewards Visa Signature ( ) - Ending in 8067": {
+    "bofa_travel": {
       "categories": {
         "Travel": 0.015
       },
       "default_cashback": 0.01
     },
-    "Citi Custom Cash Card - Ending in 9673": {
+    "citi_custom_cash": {
       "categories": {
-        "Restaurants": 0.05
+        "Restaurants": [
+          {"rate": 0.05, "valid_from": "2026-01-01", "valid_until": "2026-12-31"}
+        ]
       },
       "default_cashback": 0.01
     },
-    "Discover It Card - Ending in 7693": {
+    "discover_it": {
       "categories": {
-        "Restaurants": 0.05,
+        "Restaurants": [
+          {"rate": 0.05, "valid_from": "2026-07-01", "valid_until": "2026-09-30"}
+        ],
         "Home Improvements": 0.05
       },
       "default_cashback": 0.01
     },
-    "Chase Freedom- Ending in 8642": {
+    "chase_freedom": {
       "categories": {
         "Amazon": 0.05
       },
       "default_cashback": 0.01
     },
-    "Amazon Credit Card - Ending in 7980": {
+    "amazon_card": {
       "categories": {
         "*": 0.05
       },
       "default_cashback": 0.05
     },
-    "Blue Cash Everyday ( ) - Ending in 1006": {
+    "bofa_blue_cash": {
       "categories": {
         "Groceries": 0.03,
         "Online": 0.03,
@@ -54,7 +69,7 @@
       },
       "default_cashback": 0.01
     },
-    "Citi Double Cash Card - Ending in 1713": {
+    "citi_double_cash": {
       "categories": {
         "*": 0.02
       },

--- a/process_monthly.py
+++ b/process_monthly.py
@@ -7,6 +7,7 @@ Automatically finds the most recent transaction file and processes it.
 import os
 import sys
 import glob
+import subprocess
 from datetime import datetime
 
 try:
@@ -78,16 +79,18 @@ def main():
     
     # Ask if dry run
     dry_run = input("Run in dry-run mode (preview only)? [Y/n]: ").strip().lower()
-    dry_run_flag = "--dry-run" if not dry_run or dry_run in ['y', 'yes'] else ""
-    
-    # Build command
-    cmd = f"python3 run.py --input \"{latest_file}\" {dry_run_flag}"
-    
-    print(f"\nExecuting: {cmd}\n")
+    use_dry_run = not dry_run or dry_run in ['y', 'yes']
+
+    # Build argument list (no shell injection risk with spaces in paths)
+    cmd = [sys.executable, 'run.py', '--input', latest_file]
+    if use_dry_run:
+        cmd.append('--dry-run')
+
+    print(f"\nExecuting: {' '.join(cmd)}\n")
     print("="*60)
-    
-    # Execute the command
-    os.system(cmd)
+
+    result = subprocess.run(cmd)
+    sys.exit(result.returncode)
 
 
 if __name__ == '__main__':

--- a/run.py
+++ b/run.py
@@ -68,6 +68,17 @@ def main():
         if not validate_inputs(args):
             logger.error("Invalid inputs provided")
             sys.exit(1)
+
+        # Warn when duplicate protection is explicitly disabled
+        if not args.skip_duplicates and sys.stdin.isatty():
+            print("\n" + "!"*60)
+            print("WARNING: --skip-duplicates is disabled.")
+            print("Expenses already uploaded may be added to Splitwise again.")
+            print("!"*60)
+            response = input("Are you sure you want to continue? [y/N]: ").strip().lower()
+            if response not in ['y', 'yes']:
+                logger.info("Cancelled by user (skip-duplicates warning)")
+                sys.exit(0)
         
         # Load configuration early (needed for transaction mode)
         logger.info(f"Loading configuration from {args.config}")

--- a/src/core/expense_tracker.py
+++ b/src/core/expense_tracker.py
@@ -2,9 +2,9 @@ import csv
 import json
 import os
 from typing import List, Dict, Any, Tuple
-from datetime import datetime
 from src.utils.logger import get_logger
 from src.utils.config_loader import get_card_cashback, get_excluded_categories
+from src.utils.date_utils import parse_expense_date
 
 
 """
@@ -142,7 +142,12 @@ def process_expense_row(
     """
     try:
         original_amount = abs(float(row['Amount']))
-        cashback_rate = get_card_cashback(config, row['Account'], row['Category'])
+        raw_date = row.get('Date')
+        try:
+            parsed_date = parse_expense_date(raw_date) if raw_date else None
+        except ValueError:
+            parsed_date = None
+        cashback_rate = get_card_cashback(config, row['Account'], row['Category'], parsed_date)
         cashback_amount = original_amount * cashback_rate
         final_amount = original_amount - cashback_amount
         
@@ -183,71 +188,36 @@ def expense_should_count_check(expense: Dict[str, str], excluded_categories: set
 def format_and_get_expense_info(expense: Dict[str, str]) -> Dict[str, Any]:
     """
     Format expense data into standardized structure.
-    
+
     Args:
         expense: Raw expense data
-    
+
     Returns:
         Formatted expense dictionary
-    
+
     Raises:
         ValueError: If required fields are missing or invalid
     """
-    date = parse_expense_date(expense.get('Date', ''))
+    raw_date = expense.get('Date', '')
+    try:
+        date = parse_expense_date(raw_date)
+    except ValueError:
+        logger.warning(f"Could not parse date '{raw_date}', using original value")
+        date = raw_date
+
     description = expense.get('Description', '').strip()
     category = expense.get('Category', '').strip()
     amount = expense.get('Amount', '').strip()
-    
+
     if not all([date, description, category, amount]):
         raise ValueError("Missing required expense information")
-    
+
     return {
         'date': date,
         'description': description,
         'category': category,
         'amount': amount
     }
-
-
-def parse_expense_date(date_str: str) -> str:
-    """
-    Parse date string into YYYY-MM-DD format.
-    
-    Args:
-        date_str: Date string in various formats
-    
-    Returns:
-        Date in YYYY-MM-DD format
-    """
-    date_formats = [
-        '%m/%d/%y',      # 03/15/26
-        '%m/%d/%Y',      # 03/15/2026
-        '%Y-%m-%d',      # 2026-03-15
-    ]
-    
-    for fmt in date_formats:
-        try:
-            date_obj = datetime.strptime(date_str, fmt)
-            return date_obj.strftime('%Y-%m-%d')
-        except ValueError:
-            continue
-    
-    # Manual parsing as fallback
-    try:
-        parts = date_str.replace('/', '-').split('-')
-        if len(parts) == 3:
-            month, day, year = int(parts[0]), int(parts[1]), int(parts[2])
-            
-            # Handle 2-digit year
-            if year < 100:
-                year = 2000 + year if year < 50 else 1900 + year
-            
-            return f"{year:04d}-{month:02d}-{day:02d}"
-    except (ValueError, IndexError):
-        pass
-    
-    logger.warning(f"Could not parse date '{date_str}', using original")
-    return date_str
 
 
 def generate_expense_csv(expenses: List[Dict[str, Any]], file_path: str) -> bool:

--- a/src/core/splitwise_client.py
+++ b/src/core/splitwise_client.py
@@ -1,62 +1,129 @@
-import requests
+import json
 import os
+import time
+import requests
 from typing import Dict, Any, Optional
 from src.utils.logger import get_logger
 from src.utils.config_loader import get_splitwise_config
 
 
 """
-Enhanced Splitwise API client with improved error handling,
-duplicate detection, and dry run mode support.
+Enhanced Splitwise API client with persistent duplicate detection,
+retry logic with exponential backoff, and dry run mode support.
 """
 
 
 logger = get_logger()
 
+_DEFAULT_LOG_PATH = 'uploaded_log.json'
+_MAX_RETRIES = 3
+_RETRY_BACKOFF = [1, 2, 4]  # seconds between attempts
+
 
 class SplitwiseClient:
     """Client for interacting with Splitwise API."""
-    
-    def __init__(self, api_key: str, config: Dict[str, Any], dry_run: bool = False):
+
+    def __init__(
+        self,
+        api_key: str,
+        config: Dict[str, Any],
+        dry_run: bool = False,
+        log_path: str = _DEFAULT_LOG_PATH
+    ):
         """
         Initialize Splitwise client.
-        
+
         Args:
-            api_key: Splitwise API key
-            config: Configuration dictionary
-            dry_run: If True, don't actually send requests to API
+            api_key:  Splitwise API key
+            config:   Configuration dictionary
+            dry_run:  If True, don't send any requests to the API
+            log_path: Path to the persistent upload log JSON file
         """
         self.api_key = api_key
         self.config = config
         self.dry_run = dry_run
+        self.log_path = log_path
         self.splitwise_config = get_splitwise_config(config)
         self.base_url = 'https://secure.splitwise.com/api/v3.0'
-        self.uploaded_expenses = set()
-        
+
+        self.uploaded_expenses: set = self._load_upload_log()
+
         if dry_run:
             logger.info("Splitwise client initialized in DRY RUN mode - no expenses will be uploaded")
         else:
-            logger.info("Splitwise client initialized")
-    
+            logger.info(
+                f"Splitwise client initialized "
+                f"({len(self.uploaded_expenses)} previously uploaded expenses in log)"
+            )
+
+    # ------------------------------------------------------------------
+    # Persistent upload log
+    # ------------------------------------------------------------------
+
+    def _load_upload_log(self) -> set:
+        """Load previously uploaded expense keys from disk."""
+        if not os.path.exists(self.log_path):
+            return set()
+        try:
+            with open(self.log_path, 'r') as f:
+                data = json.load(f)
+            return set(data.get('uploaded', []))
+        except (json.JSONDecodeError, KeyError, OSError) as e:
+            logger.warning(f"Could not read upload log '{self.log_path}': {e}. Starting fresh.")
+            return set()
+
+    def _save_upload_log(self):
+        """Persist the current set of uploaded expense keys to disk."""
+        try:
+            with open(self.log_path, 'w') as f:
+                json.dump({'uploaded': sorted(self.uploaded_expenses)}, f, indent=2)
+        except OSError as e:
+            logger.error(f"Could not save upload log '{self.log_path}': {e}")
+
+    # ------------------------------------------------------------------
+    # Duplicate detection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _expense_key(expense: Dict[str, Any]) -> str:
+        return f"{expense['date']}|{expense['description']}|{expense['amount']}"
+
+    def is_duplicate(self, expense: Dict[str, Any]) -> bool:
+        """Return True if this expense exists in the persistent upload log."""
+        key = self._expense_key(expense)
+        if key in self.uploaded_expenses:
+            logger.warning(f"Duplicate expense detected: {expense['description']} (${expense['amount']})")
+            return True
+        return False
+
+    def mark_as_uploaded(self, expense: Dict[str, Any]):
+        """Record expense as uploaded and save the log to disk."""
+        self.uploaded_expenses.add(self._expense_key(expense))
+        self._save_upload_log()
+
+    # ------------------------------------------------------------------
+    # API formatting
+    # ------------------------------------------------------------------
+
     def format_expense_for_splitwise_group(
-        self, 
-        expense: Dict[str, Any], 
+        self,
+        expense: Dict[str, Any],
         group_id: str
     ) -> Dict[str, Any]:
         """
-        Format expense data for Splitwise API.
-        
+        Format expense data for the Splitwise API.
+
         Args:
-            expense: Expense dictionary
+            expense:  Expense dictionary
             group_id: Splitwise group ID
-        
+
         Returns:
             Formatted expense body for API request
         """
-        body = {
+        return {
             "cost": expense['amount'],
             "description": expense['description'],
-            "details": self.splitwise_config.get('details_suffix', 'Generated using Emanuel\'s Script'),
+            "details": self.splitwise_config.get('details_suffix', "Generated using Emanuel's Script"),
             "date": expense['date'],
             "repeat_interval": "never",
             "currency_code": self.splitwise_config.get('currency_code', 'USD'),
@@ -64,43 +131,22 @@ class SplitwiseClient:
             "group_id": group_id,
             "split_equally": self.splitwise_config.get('split_equally', True)
         }
-        return body
-    
-    def is_duplicate(self, expense: Dict[str, Any]) -> bool:
-        """
-        Check if expense has already been uploaded in this session.
-        
-        Args:
-            expense: Expense dictionary
-        
-        Returns:
-            True if duplicate, False otherwise
-        """
-        expense_key = f"{expense['date']}|{expense['description']}|{expense['amount']}"
-        
-        if expense_key in self.uploaded_expenses:
-            logger.warning(f"Duplicate expense detected: {expense['description']} (${expense['amount']})")
-            return True
-        
-        return False
-    
-    def mark_as_uploaded(self, expense: Dict[str, Any]):
-        """
-        Mark expense as uploaded to prevent duplicates.
-        
-        Args:
-            expense: Expense dictionary
-        """
-        expense_key = f"{expense['date']}|{expense['description']}|{expense['amount']}"
-        self.uploaded_expenses.add(expense_key)
-    
+
+    # ------------------------------------------------------------------
+    # API request with retry
+    # ------------------------------------------------------------------
+
     def send_expense(self, splitwise_expense: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
-        Send expense to Splitwise API.
-        
+        Send a single expense to the Splitwise API.
+
+        Retries up to 3 times with exponential backoff (1s, 2s, 4s) on
+        transient network errors and timeouts. Client errors (4xx) are not
+        retried since they indicate a data or auth problem.
+
         Args:
             splitwise_expense: Formatted expense data
-        
+
         Returns:
             Response JSON if successful, None otherwise
         """
@@ -110,100 +156,103 @@ class SplitwiseClient:
                 f"(${splitwise_expense['cost']}) on {splitwise_expense['date']}"
             )
             return {"dry_run": True, "success": True}
-        
-        request_header = {
-            'Authorization': f'Bearer {self.api_key}',
+
+        headers = {
+            'Authorization': f"Bearer {self.api_key}",
             'Accept': '*/*'
         }
         url = f'{self.base_url}/create_expense'
-        
-        try:
-            resp = requests.post(url, headers=request_header, data=splitwise_expense, timeout=30)
-            resp.raise_for_status()
-            response_json = resp.json()
-            
-            # Validate response
-            if 'expenses' not in response_json or len(response_json['expenses']) == 0:
-                error_msg = response_json.get('errors', 'Unknown error')
-                logger.error(
-                    f"Failed to create expense '{splitwise_expense['description']}': {error_msg}"
+
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                resp = requests.post(url, headers=headers, data=splitwise_expense, timeout=30)
+
+                # Client errors (bad auth, validation) — don't retry
+                if 400 <= resp.status_code < 500:
+                    logger.error(
+                        f"Client error {resp.status_code} for "
+                        f"'{splitwise_expense['description']}': {resp.text}"
+                    )
+                    return None
+
+                resp.raise_for_status()
+                response_json = resp.json()
+
+                if 'expenses' not in response_json or len(response_json['expenses']) == 0:
+                    logger.error(
+                        f"Failed to create expense '{splitwise_expense['description']}': "
+                        f"{response_json.get('errors', 'Unknown error')}"
+                    )
+                    return None
+
+                logger.info(
+                    f"Successfully uploaded: {splitwise_expense['description']} "
+                    f"(${splitwise_expense['cost']})"
                 )
-                return None
-            
-            logger.info(
-                f"Successfully uploaded: {splitwise_expense['description']} "
-                f"(${splitwise_expense['cost']})"
-            )
-            return response_json
-            
-        except requests.exceptions.Timeout:
-            logger.error(
-                f"Timeout while uploading expense '{splitwise_expense['description']}'"
-            )
-            return None
-        except requests.exceptions.RequestException as e:
-            logger.error(
-                f"Network error uploading expense '{splitwise_expense['description']}': {str(e)}"
-            )
-            return None
-        except Exception as e:
-            logger.error(
-                f"Unexpected error uploading expense '{splitwise_expense['description']}': {str(e)}"
-            )
-            return None
-    
+                return response_json
+
+            except requests.exceptions.Timeout:
+                logger.warning(
+                    f"Timeout on attempt {attempt}/{_MAX_RETRIES} "
+                    f"for '{splitwise_expense['description']}'"
+                )
+            except requests.exceptions.RequestException as e:
+                logger.warning(
+                    f"Network error on attempt {attempt}/{_MAX_RETRIES} "
+                    f"for '{splitwise_expense['description']}': {e}"
+                )
+
+            if attempt < _MAX_RETRIES:
+                sleep_secs = _RETRY_BACKOFF[attempt - 1]
+                logger.info(f"Retrying in {sleep_secs}s...")
+                time.sleep(sleep_secs)
+
+        logger.error(
+            f"All {_MAX_RETRIES} attempts failed for '{splitwise_expense['description']}'"
+        )
+        return None
+
+    # ------------------------------------------------------------------
+    # Batch upload
+    # ------------------------------------------------------------------
+
     def upload_expenses(
-        self, 
-        expenses: list, 
+        self,
+        expenses: list,
         group_id: str,
         skip_duplicates: bool = True
     ) -> Dict[str, int]:
         """
         Upload multiple expenses to Splitwise.
-        
+
         Args:
-            expenses: List of expense dictionaries
-            group_id: Splitwise group ID
-            skip_duplicates: If True, skip duplicate expenses
-        
+            expenses:        List of expense dictionaries
+            group_id:        Splitwise group ID
+            skip_duplicates: If True, skip expenses already in the upload log
+
         Returns:
             Dictionary with upload statistics
         """
-        stats = {
-            'total': len(expenses),
-            'uploaded': 0,
-            'skipped': 0,
-            'failed': 0
-        }
-        
+        stats = {'total': len(expenses), 'uploaded': 0, 'skipped': 0, 'failed': 0}
+
         for expense in expenses:
-            # Check for duplicates
             if skip_duplicates and self.is_duplicate(expense):
                 stats['skipped'] += 1
                 continue
-            
-            # Format and send expense
+
             splitwise_expense = self.format_expense_for_splitwise_group(expense, group_id)
             response = self.send_expense(splitwise_expense)
-            
+
             if response:
                 stats['uploaded'] += 1
                 self.mark_as_uploaded(expense)
             else:
                 stats['failed'] += 1
-        
-        # Log summary
-        if self.dry_run:
-            logger.info(
-                f"[DRY RUN] Would upload {stats['uploaded']} expenses, "
-                f"skip {stats['skipped']}, {stats['failed']} would fail"
-            )
-        else:
-            logger.info(
-                f"Upload complete: {stats['uploaded']} uploaded, "
-                f"{stats['skipped']} skipped, {stats['failed']} failed"
-            )
-        
-        return stats
 
-# Made with Bob
+        prefix = '[DRY RUN] ' if self.dry_run else ''
+        logger.info(
+            f"{prefix}Upload complete: {stats['uploaded']} uploaded, "
+            f"{stats['skipped']} skipped, {stats['failed']} failed"
+        )
+
+        return stats

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -1,6 +1,7 @@
 import json
 import os
-from typing import Dict, Any, List
+from datetime import datetime, date as date_type
+from typing import Dict, Any, List, Optional
 from src.utils.logger import get_logger
 
 
@@ -16,13 +17,13 @@ logger = get_logger()
 def load_config(config_path='config.json') -> Dict[str, Any]:
     """
     Load configuration from JSON file.
-    
+
     Args:
         config_path: Path to configuration file
-    
+
     Returns:
         Dictionary containing configuration data
-    
+
     Raises:
         FileNotFoundError: If config file doesn't exist
         json.JSONDecodeError: If config file is invalid JSON
@@ -43,26 +44,26 @@ def load_config(config_path='config.json') -> Dict[str, Any]:
 def validate_env_variables(required_vars: List[str]) -> Dict[str, str]:
     """
     Validate that all required environment variables are set.
-    
+
     Args:
         required_vars: List of required environment variable names
-    
+
     Returns:
         Dictionary of environment variable names and values
-    
+
     Raises:
         EnvironmentError: If any required variables are missing
     """
     missing_vars = []
     env_values = {}
-    
+
     for var in required_vars:
         value = os.environ.get(var)
         if not value:
             missing_vars.append(var)
         else:
             env_values[var] = value
-    
+
     if missing_vars:
         error_msg = (
             f"Missing required environment variables: {', '.join(missing_vars)}\n"
@@ -70,53 +71,148 @@ def validate_env_variables(required_vars: List[str]) -> Dict[str, str]:
         )
         logger.error(error_msg)
         raise EnvironmentError(error_msg)
-    
+
     logger.info("All required environment variables validated")
     return env_values
 
 
-def get_card_cashback(config: Dict[str, Any], account: str, category: str) -> float:
+def _check_single_rate(rate_dict: Dict[str, Any], check_date: date_type) -> Optional[float]:
+    """
+    Validate a single date-bounded rate dict against a given date.
+
+    Args:
+        rate_dict: Dict with 'rate' and optional 'valid_from'/'valid_until' (YYYY-MM-DD)
+        check_date: Date to validate against
+
+    Returns:
+        The rate if valid for check_date, None if outside the date range
+    """
+    rate = rate_dict.get('rate')
+    if rate is None:
+        return None
+
+    valid_from = rate_dict.get('valid_from')
+    valid_until = rate_dict.get('valid_until')
+
+    if valid_from:
+        try:
+            if check_date < datetime.strptime(valid_from, '%Y-%m-%d').date():
+                return None
+        except ValueError:
+            logger.warning(f"Invalid valid_from format: '{valid_from}'")
+
+    if valid_until:
+        try:
+            if check_date > datetime.strptime(valid_until, '%Y-%m-%d').date():
+                return None
+        except ValueError:
+            logger.warning(f"Invalid valid_until format: '{valid_until}'")
+
+    return float(rate)
+
+
+def _resolve_date_bounded_rate(rate_entry: Any, check_date: date_type) -> Optional[float]:
+    """
+    Resolve a rate entry to a float, respecting optional date bounds.
+
+    Supported formats:
+        - float/int         → always valid
+        - {"rate": float, "valid_from": "YYYY-MM-DD", "valid_until": "YYYY-MM-DD"}
+        - list of the above → first matching entry wins
+
+    Args:
+        rate_entry: Rate value in any of the supported formats
+        check_date: The expense date to check validity against
+
+    Returns:
+        The applicable rate, or None if no valid rate found for check_date
+    """
+    if isinstance(rate_entry, (int, float)):
+        return float(rate_entry)
+
+    if isinstance(rate_entry, dict):
+        return _check_single_rate(rate_entry, check_date)
+
+    if isinstance(rate_entry, list):
+        for entry in rate_entry:
+            rate = _check_single_rate(entry, check_date)
+            if rate is not None:
+                return rate
+
+    return None
+
+
+def get_card_cashback(
+    config: Dict[str, Any],
+    account: str,
+    category: str,
+    expense_date: Optional[str] = None
+) -> float:
     """
     Get cashback rate for a specific card and category.
-    
+
+    Resolves card aliases first, then looks up the rate. Rates can be plain
+    floats (always valid) or date-bounded dicts/lists for rotating categories.
+    Falls back to default_cashback when no valid rate is found for the date.
+
     Args:
         config: Configuration dictionary
-        account: Card account name
+        account: Card account name (full CSV value or alias)
         category: Expense category
-    
+        expense_date: Date of expense in YYYY-MM-DD format (defaults to today)
+
     Returns:
         Cashback rate as decimal (e.g., 0.03 for 3%)
     """
+    if expense_date:
+        try:
+            check_date = datetime.strptime(expense_date, '%Y-%m-%d').date()
+        except ValueError:
+            logger.warning(f"Invalid expense_date '{expense_date}', using today for cashback lookup")
+            check_date = date_type.today()
+    else:
+        check_date = date_type.today()
+
+    # Resolve full CSV account name to alias
+    card_aliases = config.get('card_aliases', {})
+    alias = card_aliases.get(account, account)
+
     cards = config.get('cards', {})
-    
-    if account not in cards:
-        logger.warning(
-            f"Card '{account}' not found in configuration. Using default 1% cashback."
-        )
+    if alias not in cards:
+        logger.warning(f"Card '{account}' not found in configuration. Using default 1% cashback.")
         return 0.01
-    
-    card_config = cards[account]
+
+    card_config = cards[alias]
     categories = card_config.get('categories', {})
-    
-    # Check for wildcard cashback
+    default_cashback = card_config.get('default_cashback', 0.01)
+
+    # Wildcard rate applies to all categories (e.g. amazon_card, citi_double_cash)
     if '*' in categories:
-        return categories['*']
-    
-    # Check for specific category
+        rate = _resolve_date_bounded_rate(categories['*'], check_date)
+        if rate is not None:
+            return rate
+
+    # Category-specific rate
     if category in categories:
-        return categories[category]
-    
-    # Return default cashback for this card
-    return card_config.get('default_cashback', 0.01)
+        rate = _resolve_date_bounded_rate(categories[category], check_date)
+        if rate is not None:
+            return rate
+        logger.warning(
+            f"No valid cashback rate for '{category}' on '{alias}' on {check_date}. "
+            f"Falling back to {default_cashback*100:.0f}%. "
+            f"Update config.json with current quarter's rotating categories."
+        )
+
+    return default_cashback
 
 
 def get_excluded_categories(config: Dict[str, Any]) -> List[str]:
     """
     Get list of expense categories to exclude from processing.
-    
+
     Args:
         config: Configuration dictionary
-    
+
     Returns:
         List of category names to exclude
     """
@@ -126,10 +222,10 @@ def get_excluded_categories(config: Dict[str, Any]) -> List[str]:
 def get_splitwise_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Get Splitwise-specific configuration.
-    
+
     Args:
         config: Configuration dictionary
-    
+
     Returns:
         Dictionary with Splitwise settings
     """
@@ -137,7 +233,5 @@ def get_splitwise_config(config: Dict[str, Any]) -> Dict[str, Any]:
         'default_category_id': 18,
         'currency_code': 'USD',
         'split_equally': True,
-        'details_suffix': 'Generated using Emanuel\'s Script'
+        'details_suffix': "Generated using Emanuel's Script"
     })
-
-# Made with Bob

--- a/src/utils/date_utils.py
+++ b/src/utils/date_utils.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from src.utils.logger import get_logger
+
+
+"""
+Shared date parsing utilities for the expense tracker application.
+"""
+
+
+logger = get_logger()
+
+
+def parse_expense_date(date_str: str) -> str:
+    """
+    Parse a date string into YYYY-MM-DD format.
+
+    Supports: MM/DD/YY, MM/DD/YYYY, YYYY-MM-DD, YYYY/MM/DD.
+
+    Args:
+        date_str: Date string in any of the supported formats.
+
+    Returns:
+        Date string in YYYY-MM-DD format.
+
+    Raises:
+        ValueError: If the date string cannot be parsed.
+    """
+    date_formats = [
+        '%Y-%m-%d',   # 2026-03-15
+        '%m/%d/%y',   # 03/15/26
+        '%m/%d/%Y',   # 03/15/2026
+        '%Y/%m/%d',   # 2026/03/15
+    ]
+
+    for fmt in date_formats:
+        try:
+            return datetime.strptime(date_str, fmt).strftime('%Y-%m-%d')
+        except ValueError:
+            continue
+
+    # Manual fallback for non-standard separators
+    try:
+        parts = date_str.replace('/', '-').split('-')
+        if len(parts) == 3:
+            if len(parts[0]) == 4:
+                year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
+            else:
+                month, day, year = int(parts[0]), int(parts[1]), int(parts[2])
+                if year < 100:
+                    year = 2000 + year if year < 50 else 1900 + year
+            return f"{year:04d}-{month:02d}-{day:02d}"
+    except (ValueError, IndexError):
+        pass
+
+    raise ValueError(f"Could not parse date '{date_str}'")

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,144 @@
+"""
+Tests for src/utils/config_loader.py
+"""
+import pytest
+from src.utils.config_loader import get_card_cashback, get_excluded_categories
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture config
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def config():
+    return {
+        "card_aliases": {
+            "Citi Custom Cash Card - Ending in 9673": "citi_custom_cash",
+            "Amazon Credit Card - Ending in 7980": "amazon_card",
+            "Discover It Card - Ending in 7693": "discover_it",
+        },
+        "cards": {
+            "citi_custom_cash": {
+                "categories": {
+                    "Restaurants": [
+                        {"rate": 0.05, "valid_from": "2026-01-01", "valid_until": "2026-12-31"}
+                    ]
+                },
+                "default_cashback": 0.01
+            },
+            "amazon_card": {
+                "categories": {"*": 0.05},
+                "default_cashback": 0.05
+            },
+            "discover_it": {
+                "categories": {
+                    "Restaurants": [
+                        {"rate": 0.05, "valid_from": "2026-07-01", "valid_until": "2026-09-30"}
+                    ]
+                },
+                "default_cashback": 0.01
+            },
+            "savor": {
+                "categories": {
+                    "Restaurants": 0.03,
+                    "Groceries": 0.03,
+                },
+                "default_cashback": 0.01
+            }
+        },
+        "excluded_categories": ["Credit Card Payments", "Transfers"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Alias resolution
+# ---------------------------------------------------------------------------
+
+class TestAliasResolution:
+    def test_full_name_resolves_to_alias(self, config):
+        rate = get_card_cashback(
+            config,
+            "Citi Custom Cash Card - Ending in 9673",
+            "Restaurants",
+            "2026-05-15"
+        )
+        assert rate == 0.05
+
+    def test_alias_used_directly(self, config):
+        rate = get_card_cashback(config, "savor", "Restaurants")
+        assert rate == 0.03
+
+    def test_unknown_card_returns_default(self, config):
+        rate = get_card_cashback(config, "Unknown Card", "Restaurants")
+        assert rate == 0.01
+
+
+# ---------------------------------------------------------------------------
+# Plain float rates (always valid)
+# ---------------------------------------------------------------------------
+
+class TestPlainFloatRates:
+    def test_plain_float_category_rate(self, config):
+        assert get_card_cashback(config, "savor", "Restaurants") == 0.03
+
+    def test_plain_float_default_cashback(self, config):
+        assert get_card_cashback(config, "savor", "Travel") == 0.01
+
+    def test_wildcard_rate(self, config):
+        assert get_card_cashback(config, "amazon_card", "Anything") == 0.05
+
+
+# ---------------------------------------------------------------------------
+# Date-bounded rates
+# ---------------------------------------------------------------------------
+
+class TestDateBoundedRates:
+    def test_rate_valid_within_window(self, config):
+        rate = get_card_cashback(
+            config, "citi_custom_cash", "Restaurants", "2026-06-15"
+        )
+        assert rate == 0.05
+
+    def test_rate_falls_back_outside_window(self, config):
+        """discover_it Restaurants is only valid July–Sep 2026."""
+        rate = get_card_cashback(
+            config, "discover_it", "Restaurants", "2026-05-01"
+        )
+        assert rate == 0.01  # falls back to default_cashback
+
+    def test_rate_valid_on_boundary_start(self, config):
+        rate = get_card_cashback(
+            config, "discover_it", "Restaurants", "2026-07-01"
+        )
+        assert rate == 0.05
+
+    def test_rate_valid_on_boundary_end(self, config):
+        rate = get_card_cashback(
+            config, "discover_it", "Restaurants", "2026-09-30"
+        )
+        assert rate == 0.05
+
+    def test_rate_expired_after_window(self, config):
+        rate = get_card_cashback(
+            config, "discover_it", "Restaurants", "2026-10-01"
+        )
+        assert rate == 0.01
+
+    def test_no_expense_date_uses_today(self, config):
+        """Should not raise — uses today's date as fallback."""
+        rate = get_card_cashback(config, "savor", "Groceries")
+        assert rate == 0.03
+
+
+# ---------------------------------------------------------------------------
+# Excluded categories
+# ---------------------------------------------------------------------------
+
+class TestExcludedCategories:
+    def test_returns_excluded_list(self, config):
+        excluded = get_excluded_categories(config)
+        assert "Credit Card Payments" in excluded
+        assert "Transfers" in excluded
+
+    def test_empty_config_returns_empty_list(self):
+        assert get_excluded_categories({}) == []

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,34 @@
+"""
+Tests for src/utils/date_utils.py
+"""
+import pytest
+from src.utils.date_utils import parse_expense_date
+
+
+class TestParseExpenseDate:
+    def test_yyyy_mm_dd(self):
+        assert parse_expense_date("2026-05-15") == "2026-05-15"
+
+    def test_mm_dd_yy(self):
+        assert parse_expense_date("05/15/26") == "2026-05-15"
+
+    def test_mm_dd_yyyy(self):
+        assert parse_expense_date("05/15/2026") == "2026-05-15"
+
+    def test_yyyy_slash_mm_slash_dd(self):
+        assert parse_expense_date("2026/05/15") == "2026-05-15"
+
+    def test_two_digit_year_century_boundary(self):
+        """Python strptime maps 00-68 → 2000-2068, 69-99 → 1969-1999."""
+        assert parse_expense_date("01/01/26") == "2026-01-01"
+        assert parse_expense_date("01/01/68") == "2068-01-01"
+        assert parse_expense_date("01/01/69") == "1969-01-01"
+        assert parse_expense_date("01/01/99") == "1999-01-01"
+
+    def test_invalid_date_raises(self):
+        with pytest.raises(ValueError):
+            parse_expense_date("not-a-date")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_expense_date("")

--- a/tests/test_expense_tracker.py
+++ b/tests/test_expense_tracker.py
@@ -1,0 +1,77 @@
+"""
+Tests for src/core/expense_tracker.py
+"""
+import pytest
+from src.core.expense_tracker import expense_should_count_check, ExpenseStats
+
+
+# ---------------------------------------------------------------------------
+# expense_should_count_check
+# ---------------------------------------------------------------------------
+
+class TestExpenseShouldCountCheck:
+    def test_valid_expense(self):
+        row = {'Category': 'Restaurants', 'Amount': '-45.00'}
+        excluded = {'Credit Card Payments', 'Transfers'}
+        assert expense_should_count_check(row, excluded) is True
+
+    def test_excluded_category_skipped(self):
+        row = {'Category': 'Credit Card Payments', 'Amount': '-200.00'}
+        excluded = {'Credit Card Payments'}
+        assert expense_should_count_check(row, excluded) is False
+
+    def test_positive_amount_skipped(self):
+        """Positive amounts are income/refunds — should not be processed."""
+        row = {'Category': 'Restaurants', 'Amount': '10.00'}
+        assert expense_should_count_check(row, set()) is False
+
+    def test_zero_amount_skipped(self):
+        row = {'Category': 'Restaurants', 'Amount': '0'}
+        assert expense_should_count_check(row, set()) is False
+
+    def test_invalid_amount_skipped(self):
+        row = {'Category': 'Restaurants', 'Amount': 'not-a-number'}
+        assert expense_should_count_check(row, set()) is False
+
+    def test_missing_amount_skipped(self):
+        row = {'Category': 'Restaurants'}
+        assert expense_should_count_check(row, set()) is False
+
+
+# ---------------------------------------------------------------------------
+# ExpenseStats
+# ---------------------------------------------------------------------------
+
+class TestExpenseStats:
+    def test_add_processed_accumulates(self):
+        stats = ExpenseStats()
+        stats.add_processed(50.0, 1.5, 'Restaurants')
+        stats.add_processed(20.0, 0.4, 'Groceries')
+
+        summary = stats.get_summary()
+        assert summary['processed'] == 2
+        assert summary['total_amount'] == pytest.approx(70.0)
+        assert summary['total_cashback'] == pytest.approx(1.9)
+        assert summary['net_amount'] == pytest.approx(68.1)
+
+    def test_category_breakdown(self):
+        stats = ExpenseStats()
+        stats.add_processed(30.0, 0.9, 'Restaurants')
+        stats.add_processed(10.0, 0.3, 'Restaurants')
+
+        breakdown = stats.get_summary()['category_breakdown']
+        assert breakdown['Restaurants'] == pytest.approx(40.0)
+
+    def test_add_failed_records_error(self):
+        stats = ExpenseStats()
+        stats.add_failed("bad row")
+
+        summary = stats.get_summary()
+        assert summary['failed'] == 1
+        assert "bad row" in summary['errors']
+
+    def test_add_skipped(self):
+        stats = ExpenseStats()
+        stats.add_skipped("excluded category")
+
+        assert stats.get_summary()['skipped'] == 1

--- a/tests/test_splitwise_client.py
+++ b/tests/test_splitwise_client.py
@@ -1,0 +1,100 @@
+"""
+Tests for src/core/splitwise_client.py — duplicate detection and upload log.
+"""
+import json
+import os
+import pytest
+from src.core.splitwise_client import SplitwiseClient
+
+
+@pytest.fixture
+def config():
+    return {
+        "splitwise": {
+            "default_category_id": 18,
+            "currency_code": "USD",
+            "split_equally": True,
+            "details_suffix": "Test"
+        }
+    }
+
+
+@pytest.fixture
+def expense():
+    return {
+        "date": "2026-05-15",
+        "description": "Dinner at Cava",
+        "category": "Restaurants",
+        "amount": "25.00"
+    }
+
+
+@pytest.fixture
+def client(tmp_path, config):
+    log_file = str(tmp_path / "uploaded_log.json")
+    return SplitwiseClient(
+        api_key="test_key",
+        config=config,
+        dry_run=True,
+        log_path=log_file
+    )
+
+
+class TestDuplicateDetection:
+    def test_new_expense_is_not_duplicate(self, client, expense):
+        assert client.is_duplicate(expense) is False
+
+    def test_marked_expense_is_duplicate(self, client, expense):
+        client.mark_as_uploaded(expense)
+        assert client.is_duplicate(expense) is True
+
+    def test_different_expense_is_not_duplicate(self, client, expense):
+        client.mark_as_uploaded(expense)
+        other = {**expense, "description": "Lunch at Cava"}
+        assert client.is_duplicate(other) is False
+
+
+class TestPersistentLog:
+    def test_log_persists_across_instances(self, tmp_path, config, expense):
+        log_file = str(tmp_path / "uploaded_log.json")
+
+        client1 = SplitwiseClient("key", config, dry_run=True, log_path=log_file)
+        client1.mark_as_uploaded(expense)
+
+        client2 = SplitwiseClient("key", config, dry_run=True, log_path=log_file)
+        assert client2.is_duplicate(expense) is True
+
+    def test_log_file_written_on_mark(self, tmp_path, config, expense):
+        log_file = str(tmp_path / "uploaded_log.json")
+        client = SplitwiseClient("key", config, dry_run=True, log_path=log_file)
+        client.mark_as_uploaded(expense)
+
+        assert os.path.exists(log_file)
+        with open(log_file) as f:
+            data = json.load(f)
+        assert len(data['uploaded']) == 1
+
+    def test_missing_log_starts_fresh(self, tmp_path, config):
+        log_file = str(tmp_path / "nonexistent_log.json")
+        client = SplitwiseClient("key", config, dry_run=True, log_path=log_file)
+        assert len(client.uploaded_expenses) == 0
+
+    def test_corrupted_log_starts_fresh(self, tmp_path, config):
+        log_file = tmp_path / "bad_log.json"
+        log_file.write_text("not valid json")
+        client = SplitwiseClient("key", config, dry_run=True, log_path=str(log_file))
+        assert len(client.uploaded_expenses) == 0
+
+
+class TestDryRunUpload:
+    def test_dry_run_does_not_call_api(self, client, expense):
+        """upload_expenses in dry-run mode should succeed without hitting the network."""
+        stats = client.upload_expenses([expense], group_id="12345")
+        assert stats['uploaded'] == 1
+        assert stats['failed'] == 0
+
+    def test_skip_duplicates_in_dry_run(self, client, expense):
+        client.mark_as_uploaded(expense)
+        stats = client.upload_expenses([expense], group_id="12345", skip_duplicates=True)
+        assert stats['skipped'] == 1
+        assert stats['uploaded'] == 0


### PR DESCRIPTION

- Extract parse_expense_date into src/utils/date_utils.py, removing
  duplicate implementations from expense_tracker.py and add_transaction.py
- Add card_aliases to config.json so short stable keys are used in cards{};
  config_loader resolves full CSV account names via the alias map
- Support date-bounded cashback rates in config.json (valid_from/valid_until)
  with first-match-wins list resolution in config_loader
- Persist uploaded expense keys to uploaded_log.json across runs, replacing
  the previous in-memory-only duplicate detection in SplitwiseClient
- Add retry with exponential backoff (1s, 2s, 4s) in send_expense; 4xx
  client errors are not retried
- Replace os.system() with subprocess.run() in process_monthly.py to
  eliminate shell injection risk from paths containing spaces
- Add duplicate-protection warning in run.py when --skip-duplicates is off
- Add 40 unit tests covering date parsing, cashback rate resolution,
  alias lookup, persistent log, and dry-run upload behavior